### PR TITLE
more syntax highlighting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ If there is any problems, please feel free to open a new issue.
 
 ## Importing
 
-    import (
-        "github.com/likexian/whois-parser-go"
-    )
+```go
+import (
+    "github.com/likexian/whois-parser-go"
+)
+```
 
 ## Documentation
 


### PR DESCRIPTION
Also missing highlighting for `import`:

* https://github.com/likexian/doh-go
* https://github.com/likexian/host-stat-go

I can open pull requests for those if you would like