### PR TITLE
Update rule.go

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -50,7 +50,7 @@ var (
 		"domain nameservers":                     "name_servers",
 		"domain name servers":                    "name_servers",
 		"domain servers in listed order":         "name_servers",
-		"dns",					  "name_servers",
+		"dns":					  "name_servers",
 		"created":                                "created_date",
 		"registered":                             "created_date",
 		"created on":                             "created_date",

--- a/rule.go
+++ b/rule.go
@@ -50,6 +50,7 @@ var (
 		"domain nameservers":                     "name_servers",
 		"domain name servers":                    "name_servers",
 		"domain servers in listed order":         "name_servers",
+		"dns",					  "name_servers",
 		"created":                                "created_date",
 		"registered":                             "created_date",
 		"created on":                             "created_date",


### PR DESCRIPTION
Some TLDs like .rs have nameservers info listed as DNS. With current setup you get empty result when you try to print Nameservers. Adding this line fixes that problem.