### PR TITLE
Throw custom error for premium domains and brand block

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -33,6 +33,8 @@ var (
 	ErrDomainNotFound    = errors.New("Domain is not found.")
 	ErrDomainInvalidData = errors.New("Domain whois data invalid.")
 	ErrDomainLimitExceed = errors.New("Domain query limit exceeded.")
+	ErrPremiumDomain     = errors.New("The domain is not registered, but available at a premium price.")
+	ErrBlockedDomain     = errors.New("The domain name is blocked due to a DPML brand name block.")
 )
 
 // Version returns package version
@@ -57,6 +59,10 @@ func Parse(text string) (whoisInfo WhoisInfo, err error) {
 		err = ErrDomainInvalidData
 		if IsNotFound(text) {
 			err = ErrDomainNotFound
+		} else if IsPremiumDomain(text) {
+			err = ErrPremiumDomain
+		} else if IsDomainBlock(text) {
+			err = ErrBlockedDomain
 		} else if IsLimitExceeded(text) {
 			err = ErrDomainLimitExceed
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -183,3 +183,27 @@ func TestWhoisParser(t *testing.T) {
 	err = xfile.WriteText("./examples/README.md", strings.TrimSpace(verified))
 	assert.Nil(t, err)
 }
+
+func TestWhoisParser_BlockedDomain(t *testing.T) {
+	// from `whois google.chat`
+	_, err := Parse("The registration of this domain is restricted, as it is currently protected by a DPML Block. Additional information can be found at http://www.donuts.domains/what-we-do/brand-protection.")
+	assert.Equal(t, err, ErrBlockedDomain)
+}
+
+func TestWhoisParser_PremiumDomain(t *testing.T) {
+	// from `good.games`
+	_, err := Parse("This platinum domain is available for purchase. If you would like to make an offer, please contact platinums@donuts.email.")
+	assert.Equal(t, err, ErrPremiumDomain)
+
+	// from `cool.guru`
+	_, err = Parse("This premium domain is available for purchase. If you would like to make an offer, please contact platinums@donuts.email.")
+	assert.Equal(t, err, ErrPremiumDomain)
+
+	// from `cool.fyi`
+	_, err = Parse("This name is reserved by the Registry in accordance with ICANN Policy.")
+	assert.Equal(t, err, ErrPremiumDomain)
+
+	// from `good.download`
+	_, err = Parse("Reserved Domain Name")
+	assert.Equal(t, err, ErrPremiumDomain)
+}

--- a/utils.go
+++ b/utils.go
@@ -50,6 +50,41 @@ func IsNotFound(data string) bool {
 	return false
 }
 
+// IsPremiumDomain returns if the domain name is available to register at a premium price
+func IsPremiumDomain(data string) bool {
+	notExistsKeys := []string{
+		"reserved domain name",
+		"reserved by the registry",
+		"available for purchase",
+	}
+
+	data = strings.ToLower(data)
+	for _, v := range notExistsKeys {
+		if strings.Contains(data, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsDomainBlock returns if the domain name is blocked due to a DPML brand name block
+func IsDomainBlock(data string) bool {
+	notExistsKeys := []string{
+		"The registration of this domain is restricted",
+		"dpml block",
+	}
+
+	data = strings.ToLower(data)
+	for _, v := range notExistsKeys {
+		if strings.Contains(data, v) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsLimitExceeded returns is query limit
 func IsLimitExceeded(data string) bool {
 	data = strings.ToLower(data)


### PR DESCRIPTION
If a domain is blocked due to a [Donuts DPML brand block](https://donuts.domains/what-we-do/brand-protection), or registerable at a premium price by contracting the registrar, the whois query might return unconventional output.

```
> whois google.chat
...
The registration of this domain is restricted, as it is currently protected by a DPML Block. Additional information can be found at http://www.donuts.domains/what-we-do/brand-protection.
```

```
> whois good.download
...
This platinum domain is available for purchase. If you would like to make an offer, please contact platinums@donuts.email.
```

This currently causes the whois-parser code to return an `ErrDomainInvalidData` error, which implies there is an error with the querying. So I added custom errors detecting these two additional domain states so the result is more explicit. 

Application code calling the library can catch the errors and decide how to handle them. This allows to use the whois-parser tool to check if a domain is registerable.