### PR TITLE
fix panic when parsing some .edu lookups

### DIFF
--- a/prepare.go
+++ b/prepare.go
@@ -165,6 +165,9 @@ func prepareEDU(text string) string {
 			if token == "" {
 				result += "\n" + v
 			} else {
+				if index >= len(tokens[token]) {
+					continue
+				}
 				// address ending now jump to phone
 				if tokens[token][index] == "Address" && strings.HasPrefix(v, "+") {
 					found := xslice.Index(tokens[token], "Phone")


### PR DESCRIPTION
Parsing addresses from some .edu domain lookups causes a panic. This shouldn't happen, regardless of input. I don't understand the code well enough to know how the parsing works, but, this prevents the panics.

Fixing the parsing would be good, but we still shouldn't trust input received from the internet to not cause a panic.

This fixes issue #32 